### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://brujomaldito.visualstudio.com/e4d6dfc1-3506-4c2b-b714-0567db551e50/3be8c22c-2cf1-45f1-a0f0-6dc54ba356e8/_apis/work/boardbadge/4b944396-8d34-4ae5-a382-a7109e1d1aeb)](https://brujomaldito.visualstudio.com/e4d6dfc1-3506-4c2b-b714-0567db551e50/_boards/board/t/3be8c22c-2cf1-45f1-a0f0-6dc54ba356e8/Microsoft.RequirementCategory)
 # Cachet.OI_Python
 Testing Cachet.IO using Python script  and SQL Server
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#662](https://brujomaldito.visualstudio.com/e4d6dfc1-3506-4c2b-b714-0567db551e50/_workitems/edit/662). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.